### PR TITLE
Disable gpg signing until I can figure out why it stopped working

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -2,4 +2,4 @@
 	name = Louis Cloutier
 	email = louis.cloutier@shopify.com
 [commit]
-	gpgsign = true
+	gpgsign = false


### PR DESCRIPTION
I had not used my dotfiles in ~4 months and a recent brew upgrade seemed to make gpg signing 💥  so I'm disabling this until I can sort it out - it's interfering with `git fetch` commands and such on my end.